### PR TITLE
Add STASH_REPO_NAME and STASH_IS_ADMIN to the hook environment

### DIFF
--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPostReceiveHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPostReceiveHook.java
@@ -19,8 +19,10 @@ public class ExternalPostReceiveHook implements AsyncPostReceiveRepositoryHook, 
     private static final Logger log = LoggerFactory.getLogger(ExternalPostReceiveHook.class);
 
     private StashAuthenticationContext authCtx;
-    public ExternalPostReceiveHook(StashAuthenticationContext authenticationContext) {
+    private PermissionService permissions;
+    public ExternalPostReceiveHook(StashAuthenticationContext authenticationContext, PermissionService permissions) {
         this.authCtx = authenticationContext;
+        this.permissions = permissions;
     }
         
     /**
@@ -42,11 +44,18 @@ public class ExternalPostReceiveHook implements AsyncPostReceiveRepositoryHook, 
         }
 
         StashUser currentUser = authCtx.getCurrentUser();
+        boolean isAdmin =
+           permissions.hasRepositoryPermission(currentUser, repo, Permission.REPO_ADMIN) ||
+           permissions.hasProjectPermission(currentUser, repo.getProject(), Permission.PROJECT_ADMIN) ||
+           permissions.hasAnyUserPermission(currentUser, Permission.SYS_ADMIN) ||
+           permissions.hasAnyUserPermission(currentUser, Permission.ADMIN)
+        ;
         ProcessBuilder pb = new ProcessBuilder(exe);
         Map<String, String> env = pb.environment();
         env.put("STASH_USER_NAME", currentUser.getName());
         env.put("STASH_USER_EMAIL", currentUser.getEmailAddress());
         env.put("STASH_REPO_NAME", repo.getName());
+        env.put("STASH_IS_ADMIN", String.valueOf(isAdmin));
         pb.directory(new File(repo_path));
         pb.redirectErrorStream(true);
         try {

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -21,6 +21,7 @@
   <!-- import from the product container -->
   <component-import key="applicationProperties" interface="com.atlassian.sal.api.ApplicationProperties"/>
   <component-import key="stashAuthenticationContext" interface="com.atlassian.stash.user.StashAuthenticationContext" />
+  <component-import key="permissions" interface="com.atlassian.stash.user.PermissionService" />
   <repository-hook name="External Pre Receive Hook" i18n-name-key="external-pre-receive-hook.name" key="external-pre-receive-hook" class="com.ngs.stash.externalhooks.hook.ExternalPreReceiveHook">
     <description key="external-pre-receive-hook.description">The External Pre Receive Hook Plugin</description>
     <icon>icon-example.png</icon>


### PR DESCRIPTION
I was looking to use these in my external hooks: 
   • STASH_REPO_NAME - useful for logging and for rejected push responses.
   • STASH_IS_ADMIN - useful for allowing certain users to push by permission (in some cases)

I did **not** bump the revision in the pom.xml file.
