### PR TITLE
Added options for what to do when the hook response exceeds 65K

### DIFF
--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPreReceiveHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPreReceiveHook.java
@@ -70,15 +70,17 @@ public class ExternalPreReceiveHook implements PreReceiveRepositoryHook, Reposit
             if (hookResponse != null) {
                 int data;
                 int count = 0;
+                boolean clipOutput = context.getSettings().getBoolean("clipOutput", true);
                 while ((data = input.read()) >= 0) {
-                    if (count >= 65000) {
+                    if (clipOutput && count >= 65000) {
                         hookResponse.err().print("\n");
                         hookResponse.err().print("Hook response exceeds 65K length limit.\n");
                         hookResponse.err().print("Further output will be trimmed.\n");
 
                         process.destroy();
-
-                        return true;
+                        //if no setting, default is to reject
+                        boolean rejectWhenClipped = context.getSettings().getBoolean("rejectWhenClipped", true);
+                        return rejectWhenClipped;
                     }
 
                     String char_to_write = Character.toString((char)data);

--- a/src/main/resources/static/external-pre-receive-hook.soy
+++ b/src/main/resources/static/external-pre-receive-hook.soy
@@ -20,4 +20,22 @@
         {param descriptionText: 'A list of positional parameters that will be passed to an executable (one per line).' /}
         {param errorTexts: $errors ? $errors['params'] : null /}
     {/call}
+    {call aui.form.checkboxField}
+       {param legendContent: 'Response output' /}
+       {param fields: [[
+         'id': 'clipOutput',
+         'labelText': 'Clip large output',
+         'isChecked': $config ? $config['clipOutput'] : 'true'
+       ]] /}
+       {param descriptionText: 'When the hook response exceeds 65K, stop processing and return' /}
+    {/call}
+    {call aui.form.checkboxField}
+       {param legendContent: '' /}
+       {param fields: [[
+         'id': 'rejectWhenClipped',
+         'labelText': 'Reject push when output is clipped',
+         'isChecked': $config ? $config['rejectWhenClipped'] : 'true'
+       ]] /}
+       {param descriptionText: 'When the hook response is clipped, reject the push' /}
+    {/call}
 {/template}


### PR DESCRIPTION
As I stated in my comment to the parent changeset, I believe that returning true when the output exceeds 65K is a bug (and it could lead to change sets which violate what the hooks are designed to keep out).  

If you think that I am wrong about this, I have also coded a [change](https://github.com/rappazzo/atlassian-external-hooks/commit/06ec056bcd24779fda2a5d415e8059b62d946be9) that would allow the hook setup to specify what occurs when there is excessive output.  In that case, please reject this pull request, and indicate that I should make a pull request for that change set.
