### PR TITLE
Add very useful STASH_REPO_TYPE env var

### DIFF
--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPreReceiveHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalPreReceiveHook.java
@@ -100,6 +100,8 @@ public class ExternalPreReceiveHook
         }
         env.put("STASH_REPO_NAME", repo.getName());
 
+        env.put("STASH_REPO_TYPE", String.valueOf(repo.getProject().getType()));
+
         boolean isAdmin = permissions.hasRepositoryPermission(
             currentUser, repo, Permission.REPO_ADMIN);
         boolean isWrite = permissions.hasRepositoryPermission(currentUser, repo, Permission.REPO_WRITE);


### PR DESCRIPTION
This is very useful for differentiating between personal and normal projects, so that for example only normal projects have tests performed, etc
