### PR TITLE
Update to the 5.0 APIs, and now pass in the quarantine environment variables

### DIFF
--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalAsyncPostReceiveHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalAsyncPostReceiveHook.java
@@ -3,18 +3,15 @@ package com.ngs.stash.externalhooks.hook;
 import com.atlassian.bitbucket.hook.repository.*;
 import com.atlassian.bitbucket.repository.*;
 import com.atlassian.bitbucket.setting.*;
-import com.atlassian.bitbucket.user.*;
 import com.atlassian.bitbucket.auth.*;
 import com.atlassian.bitbucket.permission.*;
-import com.ngs.stash.externalhooks.hook.*;
 import com.atlassian.bitbucket.server.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.Collection;
 
 
 public class ExternalAsyncPostReceiveHook
-    implements AsyncPostReceiveRepositoryHook, RepositorySettingsValidator
+    implements PostRepositoryHook<RepositoryHookRequest>, RepositorySettingsValidator
 {
     private static final Logger log = LoggerFactory.getLogger(
         ExternalAsyncPostReceiveHook.class);
@@ -36,15 +33,12 @@ public class ExternalAsyncPostReceiveHook
         this.properties = properties;
     }
 
-    @Override
-    public void postReceive(
-        RepositoryHookContext context,
-        Collection<RefChange> refChanges
-    ) {
+	@Override
+	public void postUpdate(PostRepositoryHookContext context, RepositoryHookRequest request) {
         ExternalPreReceiveHook impl = new ExternalPreReceiveHook(
-            this.authCtx, this.permissions, this.repoService, this.properties);
-        impl.onReceive(context, refChanges, null);
-    }
+                this.authCtx, this.permissions, this.repoService, this.properties);
+            impl.preUpdateImpl(context, request);
+	}
 
     @Override
     public void validate(


### PR DESCRIPTION
I've updated the code to properly use the new 5.0 hook APIs, as well as pass in the environment variables. This will make it work with the newer versions of Git.

I'm not sure how to properly update the pom.xml here, so I will leave that to @seletskiy or someone else who can suggest. The plugin may need to be marked as 5.0+ only now as well, though I'm not sure.

@bturner if you're able to take a look and give feedback, that would be very welcome.