### PR TITLE
Add two new options for merge checks

### DIFF
--- a/src/main/resources/static/external-merge-check-hook.soy
+++ b/src/main/resources/static/external-merge-check-hook.soy
@@ -61,4 +61,27 @@
             ]
         ]/}
     {/call}
+	
+	{call aui.form.checkboxField}
+        {param legendContent: 'Cache Check Results' /}
+        {param fields: [
+            [
+                'id': 'cache_pr_results',
+                'labelText': 'Cache results of pull request check',
+                'descriptionText': 'If unchecked the executable will be run every time the pull request page is opened.',
+                'isChecked': $config ? $config['cache_pr_results'] : true
+            ]
+        ]/}
+    {/call}
+	
+	{call aui.form.checkboxField}
+        {param legendContent: 'Include Details In Tooltip' /}
+        {param fields: [
+            [
+                'id': 'detailed_tooltip',
+                'labelText': 'Include detailed results of the pull request check in the merge button tooltip',
+                'isChecked': $config ? $config['detailed_tooltip'] : false
+            ]
+        ]/}
+    {/call}	
 {/template}


### PR DESCRIPTION
Add two new options for merge checks: Toggle result caching, and Include Details in summary (merge button tooltip)

I coded up these new options because we have need for them. We have been using an older version of the External Hooks plugin that had this behavior, but after upgrading we discovered that the new version had changed behavior.

First, we need our merge check results to be run each time the page is refreshed, rather than cached. This is because one of our hooks checks to see if the branch being merged has already been merged into a different branch. If it hasn't been merged yet, we return information about where the branch needs to be merged before this pull request can proceed. If this result is cached, then even if the user goes and merges the branch where it needs to go, the pull request will continue to show the error (since the merge doesn't change the current branch or the target branch.)

Second, we prefer to see the details of the check failure displayed in the tooltip of the Merge button, rather than as a comment to the pull request. This is especially important given the issue described in the paragraph above. If we didn't cache the results, we would get multiple comments logged to the pull request.

In summary, our normal workflow is to always have the merge check run, and to display the details of a failure in the tooltip of the Merge button (i.e. return the details in the summary portion of the RepositoryHookResult.)

If you would like any changes to be made, or code cleanup, I'll be happy to work on them. Thanks for considering my pull request.