### PR TITLE
Fix for build with Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,10 +123,10 @@
             <version>1.13</version>
             <scope>provided</scope>
         </dependency>
-	<dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>2.3.3</version>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
             <version>1.13</version>
             <scope>provided</scope>
         </dependency>
+	<dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>2.3.3</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Since Java 11, java.xml.bind is removed.
See:
https://www.oracle.com/technetwork/java/javase/11-relnote-issues-5012449.html#JDK-8190378