### PR TITLE
BugFix - Column Name Case Sensitivity

### DIFF
--- a/src/main/java/com/ngs/stash/externalhooks/dao/GlobalHookSettingsDao.java
+++ b/src/main/java/com/ngs/stash/externalhooks/dao/GlobalHookSettingsDao.java
@@ -28,7 +28,7 @@ public class GlobalHookSettingsDao {
   public GlobalHookSettings get(String hookKey) {
     GlobalHookSettings[] items = ao.find(
         GlobalHookSettings.class,
-        Query.select().from(GlobalHookSettings.class).where("hook = ?", hookKey));
+        Query.select().from(GlobalHookSettings.class).where("HOOK = ?", hookKey));
     if (items.length == 0) {
       return null;
     }


### PR DESCRIPTION
This fixes #125 Postgres-backed BitBucket Server installations, where column names are case sensitive.  A new installation of External Hooks on a Postgres-backed BitBucket instance will throw errors on the Global Hooks admin page without this change